### PR TITLE
detect and fix flaky tests

### DIFF
--- a/src/main/java/net/hydromatic/morel/compile/CalciteCompiler.java
+++ b/src/main/java/net/hydromatic/morel/compile/CalciteCompiler.java
@@ -69,7 +69,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -775,7 +775,7 @@ public class CalciteCompiler extends Compiler {
   }
 
   private static EvalEnv evalEnvOf(Environment env) {
-    final Map<String, Object> map = new HashMap<>();
+    final Map<String, Object> map = new LinkedHashMap<>();
     env.forEachValue(map::put);
     EMPTY_ENV.visit(map::putIfAbsent);
     return EvalEnvs.copyOf(map);

--- a/src/main/java/net/hydromatic/morel/compile/TypeMap.java
+++ b/src/main/java/net/hydromatic/morel/compile/TypeMap.java
@@ -30,7 +30,7 @@ import com.google.common.collect.ImmutableSortedMap;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -45,7 +45,7 @@ public class TypeMap {
   public final TypeSystem typeSystem;
   private final Map<AstNode, Unifier.Term> nodeTypeTerms;
   final Unifier.Substitution substitution;
-  private final Map<String, TypeVar> typeVars = new HashMap<>();
+  private final Map<String, TypeVar> typeVars = new LinkedHashMap<>();
 
   TypeMap(TypeSystem typeSystem, Map<AstNode, Unifier.Term> nodeTypeTerms,
       Unifier.Substitution substitution) {

--- a/src/test/java/net/hydromatic/morel/MainTest.java
+++ b/src/test/java/net/hydromatic/morel/MainTest.java
@@ -67,6 +67,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 /**
  * Kick the tires.
@@ -2114,7 +2115,7 @@ public class MainTest {
     final String ml = "from s in [\"abc\", \"\", \"d\"],\n"
         + "    c in explode s\n"
         + "  group s compute count = sum of 1";
-    ml(ml).assertEvalIter(equalsOrdered(list(3, "abc"), list(1, "d")));
+    ml(ml).assertEvalIter(equalsUnordered(list(3, "abc"), list(1, "d")));
   }
 
   @Test void testJoinLateral() {
@@ -2333,7 +2334,7 @@ public class MainTest {
         + "  group j = i mod 2\n"
         + "  compute sum of j")
         .assertType("{j:int, sum:int} list")
-        .assertEval(is(list(list(1, 5), list(0, 3))));
+        .assertEvalIter(equalsUnordered(list(1, 5), list(0, 3)));
 
     // "compute" must not be followed by other steps
     ml("from i in [1, 2, 3] compute s = sum of i yield s + 2")

--- a/src/test/java/net/hydromatic/morel/SatTest.java
+++ b/src/test/java/net/hydromatic/morel/SatTest.java
@@ -24,12 +24,14 @@ import net.hydromatic.morel.util.Sat.Variable;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Tests satisfiability. */
 public class SatTest {
@@ -49,8 +51,11 @@ public class SatTest {
         is("(x ∨ x ∨ y) ∧ (¬x ∨ ¬y ∨ ¬y) ∧ (¬x ∨ y ∨ y)"));
 
     final Map<Variable, Boolean> solution = sat.solve(formula);
+    final Map<Variable, Boolean> expectedMap = new HashMap<Variable, Boolean>();
+    expectedMap.put(x, false);
+    expectedMap.put(y, true);
     assertThat(solution, notNullValue());
-    assertThat(solution.toString(), is("{x=false, y=true}"));
+    assertEquals(solution, expectedMap);
   }
 
   /** Tests true ("and" with zero arguments). */


### PR DESCRIPTION
## Description

- Fixed the flaky test `testBuild` `testCompute` inside the `MainTest` class.
- Fixed the flaky test `dumpToStringTwice` inside the `SatTest` class.
- Detected the flaky test `test` inside the `ScriptTest` class.
- Detected the flaky test `testNestedSchema` inside the `CalciteTest` class.


### Root Cause
All test mentioned above has been reported as flaky when run with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. 

These tests failed because the `asserteval()` method would invoke a compile process for a hard-coded code and the compile process will eventually invoke this method:

https://github.com/hydromatic/morel/blob/b3ce1d8ba7351ba6fb0dceeaf30288451fe5bf7d/src/main/java/net/hydromatic/morel/compile/Compiler.java#L710

Inside the `eval` execution, methods in `evalEnvOf()` will be invoked and a new object with the type `TypeMap` will be created. These methods and class utilize `HashMap` which do not guarantee elements' order. Therefore, unexpected results will be generated while testing.
https://github.com/hydromatic/morel/blob/b3ce1d8ba7351ba6fb0dceeaf30288451fe5bf7d/src/main/java/net/hydromatic/morel/compile/CalciteCompiler.java#L777-L778
https://github.com/hydromatic/morel/blob/b3ce1d8ba7351ba6fb0dceeaf30288451fe5bf7d/src/main/java/net/hydromatic/morel/compile/TypeMap.java#L44-L48

To reproduce run:
```
mvn -pl <module_name> edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=<test_name>
```

### Fix
Tests are fixed by changing `HashMap` to `LinkedHashMap` which can guarantee element order and change the expected result with the correct executing order. Besides, for  `testBuild` `testCompute` in  `MainTest` class I change the matcher to `equalsUnordered` to check only elements of a map instead of their orders. For `dumpToStringTwice` inside the `SatTest` I create an expected map and use `assertEquals` to compare the tested result and the expected result. 


#### Key changed/added classes in this PR

- `CalciteTest.testNestedSchema`
- `SatTest.testBuild`
- `ScriptTest.test`
- `MainTest.testCrossApplyGroup`
- `MainTest.testCompute`
