### PR TITLE
[MOREL-248] Optimize transformEager

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         java-version: [ "11" ]
-        guava-version: [ "33.4.0-jre" ]
+        guava-version: [ "33.4.5-jre" ]
         hsqldb-version: [ "" ]
         checkstyle-version: [ "" ]
         javadoc: [ false ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,14 +41,14 @@ jobs:
         javadoc: [ false ]
         include:
           - java-version: "8"
-            guava-version: "21.0"
+            guava-version: "23.1"
             hsqldb-version: "2.5.1"
             checkstyle-version: "9.3"
           - java-version: "11"
           - java-version: "17"
             javadoc: true
           - java-version: "21"
-            guava-version: "23.0"
+            guava-version: "31.1-jre"
           - java-version: "21"
 
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@ License.
     <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
     <googleformatter-maven-plugin.version>1.7.5</googleformatter-maven-plugin.version>
     <!-- We support (and test) Guava as low as 21. -->
-    <guava.version>33.4.0-jre</guava.version>
+    <guava.version>33.4.5-jre</guava.version>
     <hamcrest.version>3.0</hamcrest.version>
     <!-- We support (and test) HSQLDB as low as 2.5.1.
          In JDK 8, you must add '-Dhsqldb.version=2.5.1' because

--- a/src/main/java/net/hydromatic/morel/compile/Compiler.java
+++ b/src/main/java/net/hydromatic/morel/compile/Compiler.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -188,7 +189,7 @@ public class Compiler {
 
   /** Compiles the tuple arguments to "apply". */
   public List<Code> compileArgs(
-      Context cx, Iterable<? extends Core.Exp> expressions) {
+      Context cx, Collection<? extends Core.Exp> expressions) {
     return transformEager(expressions, e -> compile(cx, e));
   }
 

--- a/src/main/java/net/hydromatic/morel/compile/Compiler.java
+++ b/src/main/java/net/hydromatic/morel/compile/Compiler.java
@@ -34,7 +34,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -189,7 +188,7 @@ public class Compiler {
 
   /** Compiles the tuple arguments to "apply". */
   public List<Code> compileArgs(
-      Context cx, Collection<? extends Core.Exp> expressions) {
+      Context cx, List<? extends Core.Exp> expressions) {
     return transformEager(expressions, e -> compile(cx, e));
   }
 

--- a/src/main/java/net/hydromatic/morel/compile/TypeResolver.java
+++ b/src/main/java/net/hydromatic/morel/compile/TypeResolver.java
@@ -1492,8 +1492,7 @@ public class TypeResolver {
     }
   }
 
-  private List<Unifier.Term> toTerms(
-      Collection<? extends Type> types, Subst subst) {
+  private List<Unifier.Term> toTerms(List<? extends Type> types, Subst subst) {
     return transformEager(types, type -> toTerm(type, subst));
   }
 
@@ -1545,7 +1544,8 @@ public class TypeResolver {
           }
           result = b.toString();
         }
-        final List<Unifier.Term> args = toTerms(argNameTypes.values(), subst);
+        final List<Unifier.Term> args =
+            transformEager(argNameTypes.values(), t -> toTerm(t, subst));
         return unifier.apply(result, args);
       case LIST:
         final ListType listType = (ListType) type;

--- a/src/main/java/net/hydromatic/morel/compile/TypeResolver.java
+++ b/src/main/java/net/hydromatic/morel/compile/TypeResolver.java
@@ -1493,7 +1493,7 @@ public class TypeResolver {
   }
 
   private List<Unifier.Term> toTerms(
-      Iterable<? extends Type> types, Subst subst) {
+      Collection<? extends Type> types, Subst subst) {
     return transformEager(types, type -> toTerm(type, subst));
   }
 
@@ -1545,8 +1545,7 @@ public class TypeResolver {
           }
           result = b.toString();
         }
-        final List<Unifier.Term> args =
-            transformEager(argNameTypes.values(), t -> toTerm(t, subst));
+        final List<Unifier.Term> args = toTerms(argNameTypes.values(), subst);
         return unifier.apply(result, args);
       case LIST:
         final ListType listType = (ListType) type;


### PR DESCRIPTION
Tune the method `Static.transformEager`. We need to use `ImmutableList.builderWithExpectedSize(int)`, and therefore we increase the minimum Guava version to 23.1.