### PR TITLE
Add `yieldAll` step (flatMap for `from`); fix correlated subquery in scan

### DIFF
--- a/docs/query.md
+++ b/docs/query.md
@@ -116,6 +116,7 @@ The formal syntax of queries is as follows.
                                 union step (<i>u</i> &ge; 1)
     | <b>where</b> <i>exp</i>                 filter step
     | <b>yield</b> <i>exp</i>                 yield step
+    | <b>yieldAll</b> <i>exp</i>              yieldAll step
 
 <i>terminalStep</i> &rarr; <b>into</b> <i>exp</i>         into step
     | <b>compute</b> <i>exp</i>               compute step
@@ -1057,6 +1058,66 @@ The output fields are the same as the input fields.
   <b>take</b> 3;
 <i>
 val it = [1,2,3] : int list</i>
+</pre>
+
+### YieldAll step
+
+<pre>
+<b>yieldAll</b> <i>exp</i>
+</pre>
+
+#### Description
+
+Evaluates a collection-valued expression for each row and emits each
+of its elements, flattening the results. It is the relational
+equivalent of a `flatMap` (or monadic `bind`) operation, and the
+flatten-shaped sibling of [`yield`](#yield-step): where `yield` emits
+one row per input row, `yieldAll` emits every element of a collection.
+
+The expression <code><i>exp</i></code> must evaluate to a collection
+(a `list` or a `bag`). The step returns one row per element of that
+collection, so <code><b>yieldAll</b> <i>exp</i></code> is equivalent to
+a scan <code><b>,</b> v <b>in</b> <i>exp</i> <b>yield</b> v</code>. As
+for a comma-join scan, the output is a `list` if both the input and
+<code><i>exp</i></code> are lists, and a `bag` otherwise.
+
+A subsequent step refers to the flattened element as `current` (or
+`current.field` if the element is a record), just as it would refer
+to the value produced by a `yield` step. Within <code><i>exp</i></code>
+itself, `ordinal` and `current` refer to the input row. If the
+expression has type `t list`, the output collection has element type
+`t`.
+
+#### Example
+
+<pre>
+<i>(* Flatten a collection of lists. *)</i>
+<b>from</b> i <b>in</b> [[1, 2], [3], [4, 5]]
+  <b>yieldAll</b> i;
+<i>
+val it = [1,2,3,4,5] : int list</i>
+</pre>
+
+Emitting a singleton to keep a row, or an empty collection to drop it,
+lets <code><b>yieldAll</b></code> express the same filtering as `where`:
+
+<pre>
+<b>from</b> i <b>in</b> [1, 2, 3, 4]
+  <b>yieldAll</b> (<b>if</b> i <b>mod</b> 2 = 0 <b>then</b> [i] <b>else</b> []);
+<i>
+val it = [2,4] : int list</i>
+</pre>
+
+Because <code><b>yieldAll</b></code> expands a collection that may depend
+on the current row, it expresses a correlated (lateral) join. In the
+following query the subquery references the outer variable
+<code>e</code>:
+
+<pre>
+<b>from</b> e <b>in</b> [1, 2, 3]
+  <b>yieldAll</b> (<b>from</b> i <b>in</b> [1, 2] <b>yield</b> e * i);
+<i>
+val it = [1,2,2,4,3,6] : int list</i>
 </pre>
 
 ### Through step

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -70,7 +70,8 @@ In Morel but not Standard ML:
   `union`,
   `unorder`,
   `where`,
-  `yield` steps and `in` and `of` keywords
+  `yield`,
+  `yieldAll` steps and `in` and `of` keywords
 * `elem`,
   `implies`,
   `notelem` binary operators
@@ -233,6 +234,7 @@ In Standard ML but not in Morel:
                                 union step (<i>u</i> &ge; 1)
     | <b>where</b> <i>exp</i>                 filter step
     | <b>yield</b> <i>exp</i>                 yield step
+    | <b>yieldAll</b> <i>exp</i>              yieldAll step
 <i>terminalStep</i> &rarr; <b>into</b> <i>exp</i>         into step
     | <b>compute</b> <i>exp</i>               compute step
 <i>groupKey</i> &rarr; [ <i>id</i> <b>=</b> ] <i>exp</i>

--- a/src/main/java/net/hydromatic/morel/ast/Ast.java
+++ b/src/main/java/net/hydromatic/morel/ast/Ast.java
@@ -3283,6 +3283,35 @@ public class Ast {
     }
   }
 
+  /** A {@code yieldAll} step in a {@code from} expression. */
+  public static class YieldAll extends FromStep {
+    public final Exp exp;
+
+    YieldAll(Pos pos, Exp exp) {
+      super(pos, Op.YIELD_ALL);
+      this.exp = exp;
+    }
+
+    @Override
+    AstWriter unparse(AstWriter w, int left, int right) {
+      return w.append(" yieldAll ").append(exp, 0, 0);
+    }
+
+    @Override
+    public AstNode accept(Shuttle shuttle) {
+      return shuttle.visit(this);
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+      visitor.visit(this);
+    }
+
+    public YieldAll copy(Exp exp) {
+      return this.exp.equals(exp) ? this : new YieldAll(pos, exp);
+    }
+  }
+
   /** An {@code into} step in a {@code from} expression. */
   public static class Into extends FromStep {
     public final Exp exp;

--- a/src/main/java/net/hydromatic/morel/ast/AstBuilder.java
+++ b/src/main/java/net/hydromatic/morel/ast/AstBuilder.java
@@ -751,6 +751,10 @@ public enum AstBuilder {
     return new Ast.Yield(pos, exp);
   }
 
+  public Ast.FromStep yieldAll(Pos pos, Ast.Exp exp) {
+    return new Ast.YieldAll(pos, exp);
+  }
+
   public Ast.FromStep into(Pos pos, Ast.Exp exp) {
     return new Ast.Into(pos, exp);
   }

--- a/src/main/java/net/hydromatic/morel/ast/FromBuilder.java
+++ b/src/main/java/net/hydromatic/morel/ast/FromBuilder.java
@@ -174,7 +174,8 @@ public class FromBuilder {
     if (exp.op == Op.FROM
         && core.boolLiteral(true).equals(condition)
         && isSimplePat(pat, (Core.From) exp)
-        && !containsOrdinal(exp)) {
+        && !containsOrdinal(exp)
+        && !unsafeToInline((Core.From) exp)) {
       final Core.From from = (Core.From) exp;
       final Core.FromStep lastStep = last(from.steps);
       final List<Core.FromStep> steps =
@@ -270,6 +271,23 @@ public class FromBuilder {
           }
         });
     return b.get();
+  }
+
+  /**
+   * Returns whether it would be unsafe to inline the subquery {@code from} into
+   * the enclosing {@code from}, given the bindings already accumulated.
+   *
+   * <p>The inlining optimization in {@link #scan} drops the subquery's trailing
+   * {@code yield} (via {@code skipLast}) and rebuilds the projection from the
+   * subquery's surviving bindings. When this builder already has bindings (that
+   * is, the scan is a join rather than the first step) and the subquery ends in
+   * a {@code yield}, the rebuilt projection references the dropped yield's
+   * binding, which is no longer in scope, and validation ({@link RefChecker})
+   * fails. In that case we fall back to a plain scan, which handles such
+   * subqueries (including correlated ones) correctly.
+   */
+  private boolean unsafeToInline(Core.From from) {
+    return !bindings.isEmpty() && last(from.steps).op == Op.YIELD;
   }
 
   private static boolean isSimplePat(Core.Pat pat, Core.From exp) {

--- a/src/main/java/net/hydromatic/morel/ast/Op.java
+++ b/src/main/java/net/hydromatic/morel/ast/Op.java
@@ -177,6 +177,7 @@ public enum Op {
   INTERSECT(" intersect "),
   UNION(" union "),
   YIELD,
+  YIELD_ALL,
   INTO,
   THROUGH,
   AGGREGATE,

--- a/src/main/java/net/hydromatic/morel/ast/Shuttle.java
+++ b/src/main/java/net/hydromatic/morel/ast/Shuttle.java
@@ -420,6 +420,10 @@ public class Shuttle {
     return ast.yield(yield.pos, yield.exp.accept(this));
   }
 
+  protected AstNode visit(Ast.YieldAll yieldAll) {
+    return ast.yieldAll(yieldAll.pos, yieldAll.exp.accept(this));
+  }
+
   protected AstNode visit(Ast.Into into) {
     return ast.into(into.pos, into.exp);
   }

--- a/src/main/java/net/hydromatic/morel/ast/Visitor.java
+++ b/src/main/java/net/hydromatic/morel/ast/Visitor.java
@@ -315,6 +315,10 @@ public class Visitor {
     yield.exp.accept(this);
   }
 
+  protected void visit(Ast.YieldAll yieldAll) {
+    yieldAll.exp.accept(this);
+  }
+
   protected void visit(Ast.Into into) {
     into.exp.accept(this);
   }

--- a/src/main/java/net/hydromatic/morel/compile/Resolver.java
+++ b/src/main/java/net/hydromatic/morel/compile/Resolver.java
@@ -1429,6 +1429,24 @@ public class Resolver {
     }
 
     @Override
+    protected void visit(Ast.YieldAll yieldAll) {
+      // Lower "yieldAll e" to a scan over the collection-valued expression "e"
+      // followed by a yield of the freshly-bound element, i.e.
+      // ", v in e yield v". The flatten (flatMap) semantics fall out of the
+      // scan-then-yield: the scan multiplies each input row by the elements of
+      // "e", then the yield drops the input bindings, keeping only the element.
+      // "e" may be correlated (reference the input row); the unsafeToInline
+      // guard in FromBuilder keeps that lowering correct.
+      final Resolver r = withStepEnv(fromBuilder.stepEnv());
+      final Core.Exp coreExp = r.toCore(yieldAll.exp);
+      final Type elementType = coreExp.type.elementType();
+      final Core.IdPat pat =
+          core.idPat(elementType, typeMap.typeSystem.nameGenerator::get);
+      fromBuilder.scan(pat, coreExp);
+      fromBuilder.yield_(core.id(pat));
+    }
+
+    @Override
     protected void visit(Ast.Compute compute) {
       visit((Ast.Group) compute);
     }

--- a/src/main/java/net/hydromatic/morel/compile/TypeResolver.java
+++ b/src/main/java/net/hydromatic/morel/compile/TypeResolver.java
@@ -1088,6 +1088,9 @@ public class TypeResolver {
       case YIELD:
         return deduceYieldStepType((Ast.Yield) step, p, fieldVars, steps);
 
+      case YIELD_ALL:
+        return deduceYieldAllStepType((Ast.YieldAll) step, p, fieldVars, steps);
+
       case ORDER:
         final Ast.Order order = (Ast.Order) step;
         final Ast.Order order2 = validateOrder(order);
@@ -1352,6 +1355,47 @@ public class TypeResolver {
       fieldVars.add(ast.id(Pos.ZERO, label), v6);
     }
     return Triple.of(p.rootEnv, envs.typeEnv, v6, c6);
+  }
+
+  /**
+   * Deduces the type of a {@code yieldAll} step.
+   *
+   * <p>"yieldAll e" evaluates the collection-valued expression "e" for each
+   * input row and emits each of its elements, flattening the result -- the
+   * relational equivalent of flatMap (monadic bind). It is type-checked here as
+   * a first-class step, so that "ordinal" and "current" resolve against the
+   * input row and a type error points at "e" itself; it is lowered to a scan
+   * followed by a yield in {@link Resolver}. Flatten semantics: the prior
+   * bindings are dropped and each element of "e" becomes a row, visible
+   * downstream as "current".
+   */
+  private Triple deduceYieldAllStepType(
+      Ast.YieldAll yieldAll,
+      Triple p,
+      PairList<Ast.Id, Variable> fieldVars,
+      List<Ast.FromStep> steps) {
+    final Variable elem = unifier.variable();
+    final Variable c0 = unifier.variable();
+    final Ast.Exp exp = deduceExpType(p.env, yieldAll.exp, c0);
+    reg(yieldAll.exp, c0);
+    // "e" must evaluate to a list or a bag (of element type "elem").
+    mayBeBagOrList(c0, elem);
+    // The output is a list if both the input and "e" are lists, and a bag if
+    // either is a bag -- the same rule as a comma-join scan.
+    final Variable c = unifier.variable();
+    isListIfBothAreLists(
+        requireNonNull(p.c),
+        unifier.variable(),
+        c0,
+        unifier.variable(),
+        c,
+        elem);
+    steps.add(yieldAll.copy(exp));
+    final TypeEnvHolder envs = new TypeEnvHolder(p.rootEnv);
+    envs.bind(Op.CURRENT.opName, elem);
+    fieldVars.clear();
+    fieldVars.add(ast.id(Pos.ZERO, Op.CURRENT.opName), elem);
+    return Triple.of(p.rootEnv, envs.typeEnv, elem, c);
   }
 
   private Triple deduceGroupStepType(

--- a/src/main/java/net/hydromatic/morel/util/MorelHighlighter.java
+++ b/src/main/java/net/hydromatic/morel/util/MorelHighlighter.java
@@ -128,7 +128,8 @@ public class MorelHighlighter {
           "take",
           "unorder",
           "union",
-          "yield");
+          "yield",
+          "yieldAll");
 
   /**
    * DML keywords, not active by default. Pass to {@link

--- a/src/main/javacc/MorelParser.jj
+++ b/src/main/javacc/MorelParser.jj
@@ -576,7 +576,7 @@ void fromFirstScan(List<FromStep> steps) :
   LOOKAHEAD(
       (<IDENTIFIER> | <QUOTED_IDENTIFIER>)
       (<COMMA> | <JOIN> | <WHERE> | <GROUP> | <COMPUTE>
-        | <SKIP_> | <TAKE> | <YIELD> | <EOF>))
+        | <SKIP_> | <TAKE> | <YIELD> | <YIELDALL> | <EOF>))
   id = identifier() {
     pat = ast.idPat(id.pos, id.name);
     steps.add(ast.scan(id.pos.plus(pos()), pat, null, null));
@@ -605,7 +605,7 @@ void fromScan(List<FromStep> steps) :
   LOOKAHEAD(
       (<IDENTIFIER> | <QUOTED_IDENTIFIER>)
       (<COMMA> | <JOIN> | <WHERE> | <GROUP> | <COMPUTE>
-        | <SKIP_> | <TAKE> | <YIELD> | <EOF>))
+        | <SKIP_> | <TAKE> | <YIELD> | <YIELDALL> | <EOF>))
   id = identifier() {
     pat = ast.idPat(id.pos, id.name);
     steps.add(ast.scan(id.pos.plus(pos()), pat, null, null));
@@ -725,6 +725,10 @@ void fromStep(List<FromStep> steps) :
 |
   <YIELD> { span = Span.of(pos()); } yieldExp = expression() {
     steps.add(ast.yield(span.end(this), yieldExp));
+  }
+|
+  <YIELDALL> { span = Span.of(pos()); } yieldExp = expression() {
+    steps.add(ast.yieldAll(span.end(this), yieldExp));
   }
 }
 
@@ -2381,6 +2385,7 @@ AstNode statementEof() :
 | < WHERE: "where" >
 | < WITH: "with" >
 | < YIELD: "yield" >
+| < YIELDALL: "yieldAll" >
 
 // The following are extensions for overloaded operators:
 | < INST: "inst" >

--- a/src/test/resources/script/bag.smli
+++ b/src/test/resources/script/bag.smli
@@ -197,6 +197,19 @@ from i in intBag, j in intBag where i = j;
 > val it = [{i=1,j=1},{i=1,j=1},{i=2,j=2},{i=1,j=1},{i=1,j=1},{i=3,j=3}]
 >   : {i:int, j:int} bag
 
+(*) 'yieldAll' output is a list iff both the input and the expression are
+(*) lists, otherwise a bag -- the same rule as a comma-join scan.
+from i in intList yieldAll [i];
+> val it = [1,2,1,3] : int list
+from i in intList yieldAll bag [i];
+> val it = [1,2,1,3] : int bag
+from i in intBag yieldAll [i];
+> val it = [1,2,1,3] : int bag
+from i in intBag yieldAll bag [i];
+> val it = [1,2,1,3] : int bag
+from i in bag [1, 2] yieldAll bag [i];
+> val it = [1,2] : int bag
+
 from h in [] join i in intList, j in intList where i = j;
 > val it = [] : {h:'a, i:int, j:int} list
 from h in bag [] join i in intList, j in intList where i = j;

--- a/src/test/resources/script/relational.smli
+++ b/src/test/resources/script/relational.smli
@@ -177,6 +177,64 @@ from p in [{x = 1, y = 2},{x = 3, y = 5}]
 from e in [1, 2, 3], v in (from i in [1, 2] yield e * i) yield v;
 > val it = [1,2,2,4,3,6] : int list
 
+(*) 'yieldAll' evaluates a collection-valued expression for each input row
+(*) and emits each of its elements, flattening (monadic flatMap). The
+(*) flattened element becomes the current value, referenced as 'current'.
+from x in [[1,2],[3],[4,5]] yieldAll x;
+> val it = [1,2,3,4,5] : int list
+
+(*) 'yieldAll' over records; downstream steps see the element as 'current'
+from i in [{a=1},{a=2}] yieldAll [{b=i.a},{b=i.a+10}];
+> val it = [{b=1},{b=11},{b=2},{b=12}] : {b:int} list
+
+(*) 'yieldAll e' is equivalent to ', v in e yield v'
+from i in [{a=1},{a=2}], j in [{b=i.a},{b=i.a+10}] yield j;
+> val it = [{b=1},{b=11},{b=2},{b=12}] : {b:int} list
+
+(*) A step after a scalar 'yieldAll' refers to the element via 'current'
+from xs in [[1,2,3],[4,5]] yieldAll xs where current mod 2 = 0;
+> val it = [2,4] : int list
+
+(*) A step after a record 'yieldAll' refers to fields via 'current.field'
+from i in [{a=1},{a=2}] yieldAll [{b=i.a},{b=i.a+10}] where current.b > 5;
+> val it = [{b=11},{b=12}] : {b:int} list
+
+(*) 'yieldAll' over empty collections emits nothing for those rows
+from x in [[],[1],[]] yieldAll x;
+> val it = [1] : int list
+
+(*) 'yieldAll' can emulate 'where': emit a singleton to keep a row, empty to
+(*) drop it.
+from i in [1, 2, 3, 4] yieldAll (if i mod 2 = 0 then [i] else []);
+> val it = [2,4] : int list
+
+(*) 'ordinal' and 'current' are in scope in the 'yieldAll' expression and
+(*) refer to the input row.
+from i in [10, 20] yieldAll [i + ordinal + current];
+> val it = [20,41] : int list
+
+(*) 'yieldAll' over a correlated subquery (the LATERAL/flatMap case): the
+(*) subquery references the outer row. This works because 'yieldAll' desugars
+(*) to a scan, '<prior>, v in e yield v'.
+from e in [1, 2, 3] yieldAll (from i in [1, 2] yield e * i);
+> val it = [1,2,2,4,3,6] : int list
+
+from e in [1, 2, 3] yieldAll (from i in [1, 2] yield e * 100 + i);
+> val it = [101,102,201,202,301,302] : int list
+
+(*) The 'yieldAll' expression must be a collection; a scalar is an error.
+(*) (This is the standard type-conflict error; 'yieldAll' adds no synthesized
+(*) scan or yield to the message.)
+from i in [1, 2] yieldAll i > 1;
+> 0.0-0.0 Error: Cannot deduce type: no valid overloads
+>   raised at: 0.0-0.0
+
+(*) A 'yieldAll' expression that references an unbound variable is an error,
+(*) reported at the offending reference.
+from i in [1, 2] yieldAll i + unknown;
+> stdIn:1.31-1.38 Error: unbound variable or constructor: unknown
+>   raised at: stdIn:1.31-1.38
+
 from e in emps
   yield {x = e.id + e.deptno, y = e.id - e.deptno}
   yield x + y;

--- a/src/test/resources/script/relational.smli
+++ b/src/test/resources/script/relational.smli
@@ -169,6 +169,14 @@ from p in [{x = 1, y = 2},{x = 3, y = 5}]
   yield case p of {x, y} => (x, y);
 > val it = [(1,2),(3,5)] : (int * int) list
 
+(*) Correlated (lateral) scan: a 'from' subquery on the right of a comma-join
+(*) that references an outer variable. Previously this crashed during
+(*) resolution ("VerifyException: not found") because subquery inlining
+(*) dropped the inner subquery's trailing 'yield' binding while keeping a
+(*) reference to it; such subqueries now fall back to a plain scan.
+from e in [1, 2, 3], v in (from i in [1, 2] yield e * i) yield v;
+> val it = [1,2,2,4,3,6] : int list
+
 from e in emps
   yield {x = e.id + e.deptno, y = e.id - e.deptno}
   yield x + y;


### PR DESCRIPTION
Adds `yieldAll`, a flatMap (SelectMany / monadic bind) step for `from`
expressions — implementing #257 — on top of a small pre-existing fix for
correlated subqueries in `scan` (a step toward #275).

Two commits, meant to be reviewed (and hand-merged) independently.

## 1. Fix correlated subquery in scan crashing during resolution

A scan whose right-hand side is a `from` subquery ending in a `yield` crashed
during Ast-to-Core resolution when the scan was a join:

```
from e in [1, 2, 3], v in (from i in [1, 2] yield e * i) yield v;
(* com.google.common.base.VerifyException: not found [v$0] *)
```

The subquery-inlining optimization in `FromBuilder.scan` drops the subquery's
trailing `yield` (via `skipLast`) and rebuilds the projection from the
surviving bindings; when the enclosing `from` already has bindings, the rebuilt
projection still references the dropped binding, which is out of scope, so
`RefChecker` fails. Guarded with `unsafeToInline`, falling back to a plain scan
(always correct; inlining is only a performance optimization). Regression test
in `relational.smli`.

## 2. Add `yieldAll` step

`yieldAll e` evaluates the collection-valued expression `e` for each input row
and emits each of its elements — the flatten-shaped sibling of `yield`.

- **Type-checked as a first-class step** (`TypeResolver.deduceYieldAllStepType`),
  then **lowered to a scan + yield after type resolution, before Core**
  (`Resolver.FromResolver.visit(Ast.YieldAll)`), modeled on the existing
  `through` step. No `Core.YieldAll`. Because the expression is type-checked in
  the input row's environment, `ordinal` and `current` resolve against the
  input row, and errors point at the expression, not synthesized internals.
- **Orderedness:** output is a `list` iff both the input and `e` are lists,
  otherwise a `bag` — the same rule as a comma-join scan.

Tests in `relational.smli` and `bag.smli` cover flattening, the four list/bag
combinations, `ordinal`/`current` in the expression, emulating `where`,
correlated (lateral) subqueries, and the error cases for a non-collection
expression and an unbound reference. Docs in `query.md` and `reference.md`.

`./mvnw clean install` is green (442 tests, 0 failures).
