### PR TITLE
[MOREL-391] Harmonize row types for set-op steps so subquery operands work

### DIFF
--- a/src/main/java/net/hydromatic/morel/compile/CalciteCompiler.java
+++ b/src/main/java/net/hydromatic/morel/compile/CalciteCompiler.java
@@ -871,6 +871,7 @@ public class CalciteCompiler extends Compiler {
       }
       ++n;
     }
+    harmonizeRowTypes(cx.relBuilder, n);
     switch (setStep.op) {
       case EXCEPT:
         cx.relBuilder.minus(!setStep.distinct, n);

--- a/src/test/java/net/hydromatic/morel/AlgebraTest.java
+++ b/src/test/java/net/hydromatic/morel/AlgebraTest.java
@@ -248,14 +248,17 @@ public class AlgebraTest {
       "from i in [1, 2, 3] intersect [2, 5, 4]",
       "from i in [1, 2, 3] intersect [2, 5, 4], [2, 1, 6]",
       "from i in [1, 2, 3] except [2, 5, 4]",
-      // Disabled because Calcite's interpreter gets the wrong answer:
+      // Disabled because Calcite's interpreter (SetOpNode) reads only two
+      // inputs, so the third operand of a chained except/intersect is dropped
+      // (a Calcite-side bug, not a Morel translation error). See #391.
       //   "from i in [1, 2, 3] except [2, 5, 4], [2, 1, 6]",
       "from i in [10, 15, 20] union (from d in scott.depts yield d.deptno)",
-      // Disabled because Calcite's interpreter gets the wrong answer:
-      //   "from i in [10, 15, 20]"
-      //       + " except (from d in scott.depts yield d.deptno)",
-      //   "from i in [10, 15, 20]"
-      //       + " intersect (from d in scott.depts yield d.deptno)",
+      // Two-input except/intersect against a JDBC-backed subquery operand now
+      // work because setStep harmonizes row types before the set op (see #391):
+      "from i in [10, 15, 20]"
+          + " except (from d in scott.depts yield d.deptno)",
+      "from i in [10, 15, 20]"
+          + " intersect (from d in scott.depts yield d.deptno)",
 
       // the following 4 are equivalent
       "from e in scott.emps where e.deptno = 30 yield e.empno",


### PR DESCRIPTION
Fixes #391.

On the Calcite/HYBRID path, a set-op (`except`, `intersect`) whose operand is a Morel-evaluated subquery returned the wrong answer: `except` behaved as a no-op and `intersect` returned the empty set. The native interpreter was correct.

### Cause

`CalciteCompiler.setStep` (the `from`-step path) builds the `minus`/`intersect`/`union` over its operands without first calling `harmonizeRowTypes`, whereas the operator-application path does. When one operand is a literal (`LogicalValues`, plain `int`) and another is a JDBC-backed subquery (`JdbcTableScan`), the two sides carry different row types. Calcite's interpreter `SetOpNode.run()` tests membership with a `HashSet<Row>`, and rows of differing type never compare equal, so the subtraction/intersection matched nothing. `union` was unaffected because it emits rows without comparing them.

### Fix

Add the missing `harmonizeRowTypes(cx.relBuilder, n)` call in `setStep`, mirroring the operator path, and re-enable the two formerly-disabled JDBC-operand cases in `AlgebraTest.testQueryList`:

```
from i in [10, 15, 20] except (from d in scott.depts yield d.deptno);     (* now [15] *)
from i in [10, 15, 20] intersect (from d in scott.depts yield d.deptno);  (* now [10, 20] *)
```

`./mvnw install` is green.

### Out of scope

The other half of the original #391, chained `except` and 3-or-more-operand `intersect`, is a separate Calcite-interpreter limitation (`SetOpNode` reads only inputs 0 and 1) and is tracked in #402. Those cases stay disabled with an explanatory comment.