### PR TITLE
[MOREL-402] Binarize multi-operand except/intersect for the Calcite path

### DIFF
--- a/src/main/java/net/hydromatic/morel/compile/CalciteCompiler.java
+++ b/src/main/java/net/hydromatic/morel/compile/CalciteCompiler.java
@@ -354,10 +354,10 @@ public class CalciteCompiler extends Compiler {
                     cx.relBuilder.union(true, tuple.args.size());
                     return true;
                   case LIST_EXCEPT:
-                    cx.relBuilder.minus(true, tuple.args.size());
+                    foldSetOp(cx.relBuilder, true, true, tuple.args.size());
                     return true;
                   case LIST_INTERSECT:
-                    cx.relBuilder.intersect(true, tuple.args.size());
+                    foldSetOp(cx.relBuilder, false, true, tuple.args.size());
                     return true;
                   default:
                     throw new AssertionError(builtIn);
@@ -475,6 +475,40 @@ public class CalciteCompiler extends Compiler {
     requireNonNull(rowType);
     for (RelNode input : Lists.reverse(inputs)) {
       relBuilder.push(input).convert(rowType, false);
+    }
+  }
+
+  /**
+   * Applies {@code minus} (if {@code minus} is true) or {@code intersect} to
+   * the top {@code n} relations on the stack, folding into a left-associative
+   * chain of two-input operations.
+   *
+   * <p>Calcite's interpreter reads only the first two inputs of a multi-input
+   * {@code Minus} or {@code Intersect} (CALCITE-7628), silently dropping the
+   * rest. Folding into two-input operations avoids that. {@code union} is
+   * unaffected and does not use this method.
+   */
+  private static void foldSetOp(
+      RelBuilder relBuilder, boolean minus, boolean all, int n) {
+    if (n < 2) {
+      return;
+    }
+    final List<RelNode> inputs = new ArrayList<>();
+    for (int i = 0; i < n; i++) {
+      inputs.add(relBuilder.build());
+    }
+    // 'inputs' is ordered top-of-stack first; reverse so that the first
+    // operand is pushed first and the fold is left-associative
+    // (a except b except c = (a except b) except c).
+    final List<RelNode> operands = Lists.reverse(inputs);
+    relBuilder.push(operands.get(0));
+    for (int i = 1; i < n; i++) {
+      relBuilder.push(operands.get(i));
+      if (minus) {
+        relBuilder.minus(all, 2);
+      } else {
+        relBuilder.intersect(all, 2);
+      }
     }
   }
 
@@ -874,10 +908,10 @@ public class CalciteCompiler extends Compiler {
     harmonizeRowTypes(cx.relBuilder, n);
     switch (setStep.op) {
       case EXCEPT:
-        cx.relBuilder.minus(!setStep.distinct, n);
+        foldSetOp(cx.relBuilder, true, !setStep.distinct, n);
         break;
       case INTERSECT:
-        cx.relBuilder.intersect(!setStep.distinct, n);
+        foldSetOp(cx.relBuilder, false, !setStep.distinct, n);
         break;
       case UNION:
         cx.relBuilder.union(!setStep.distinct, n);

--- a/src/test/java/net/hydromatic/morel/AlgebraTest.java
+++ b/src/test/java/net/hydromatic/morel/AlgebraTest.java
@@ -247,9 +247,11 @@ public class AlgebraTest {
       "from i in [1, 2, 3] union [2, 5, 4], [2, 1, 7]",
       "from i in [1, 2, 3] intersect [2, 5, 4]",
       "from i in [1, 2, 3] intersect [2, 5, 4], [2, 1, 6]",
+      // A three-operand intersect whose answer (the empty bag) differs if the
+      // third operand is dropped; guards the #402 binarization.
+      "from i in [1, 2, 3] intersect [1, 2, 3], [99]",
       "from i in [1, 2, 3] except [2, 5, 4]",
-      // Disabled pending #402.
-      //   "from i in [1, 2, 3] except [2, 5, 4], [2, 1, 6]",
+      "from i in [1, 2, 3] except [2, 5, 4], [2, 1, 6]",
       "from i in [10, 15, 20] union (from d in scott.depts yield d.deptno)",
       "from i in [10, 15, 20] except (from d in scott.depts yield d.deptno)",
       "from i in [10, 15, 20] intersect (from d in scott.depts yield d.deptno)",


### PR DESCRIPTION
Fixes #402.

Calcite's interpreter reads only the first two inputs of a multi-input `Minus` or `Intersect` ([CALCITE-7628](https://issues.apache.org/jira/browse/CALCITE-7628)), silently dropping the rest. So a chained `except`, or an `intersect` with three or more operands, returned the wrong answer on the Calcite/HYBRID path, even though the plan Morel generated was correct:

```
from i in [1, 2, 3] except [2, 5, 4], [2, 1, 6];   (* was [1, 3], should be [3] *)
```

`union` is unaffected, because a multi-input union reaches the interpreter by a different route.

### Fix

Per your suggestion on #402, fold multi-operand `minus` and `intersect` into a left-associative chain of two-input operations (`a except b except c` becomes `(a except b) except c`), in both the from-step path (`setStep`) and the operator-application path. A shared `foldSetOp` helper does this; `union` is left as a single n-input operation.

Re-enable the disabled chained-`except` case in `AlgebraTest.testQueryList`, and add a three-operand `intersect` whose answer (the empty bag) changes if the third operand is dropped, so the regression is actually guarded (the existing three-operand `intersect` passes either way by coincidence).

`./mvnw install` is green.

This is the short-term workaround; it can be reverted once a Calcite release carrying CALCITE-7628 is picked up.