### PR TITLE
[MOREL-408] Fix Calcite translation of direct List.concat/except/intersect calls

### DIFF
--- a/src/main/java/net/hydromatic/morel/compile/CalciteCompiler.java
+++ b/src/main/java/net/hydromatic/morel/compile/CalciteCompiler.java
@@ -339,26 +339,32 @@ public class CalciteCompiler extends Compiler {
               case LIST_CONCAT:
               case LIST_EXCEPT:
               case LIST_INTERSECT:
-                // For example, '[1, 2, 3] union (from scott.depts yield
-                // deptno)'
-                final Core.Tuple tuple = (Core.Tuple) apply.arg;
-                for (Core.Exp arg : tuple.args) {
+                // For example, 'List.concat [[1, 2, 3],
+                // from d in scott.depts yield d.deptno]'. The argument is a
+                // list of collections, represented as a call to Z_LIST.
+                if (!apply.arg.isCallTo(BuiltIn.Z_LIST)) {
+                  break;
+                }
+                final List<Core.Exp> collections =
+                    ((Core.Apply) apply.arg).args();
+                for (Core.Exp arg : collections) {
                   if (!CalciteCompiler.this.toRel3(cx, arg, false)) {
                     return false;
                   }
                 }
-                harmonizeRowTypes(cx.relBuilder, tuple.args.size());
+                harmonizeRowTypes(cx.relBuilder, collections.size());
                 switch (builtIn) {
                   case BAG_CONCAT:
                   case LIST_CONCAT:
-                    cx.relBuilder.union(true, tuple.args.size());
+                    cx.relBuilder.union(true, collections.size());
                     return true;
                   case LIST_EXCEPT:
-                    foldSetOp(cx.relBuilder, Op.MINUS, true, tuple.args.size());
+                    foldSetOp(
+                        cx.relBuilder, Op.EXCEPT, true, collections.size());
                     return true;
                   case LIST_INTERSECT:
                     foldSetOp(
-                        cx.relBuilder, Op.EXCEPT, true, tuple.args.size());
+                        cx.relBuilder, Op.INTERSECT, true, collections.size());
                     return true;
                   default:
                     throw new AssertionError(builtIn);

--- a/src/test/java/net/hydromatic/morel/AlgebraTest.java
+++ b/src/test/java/net/hydromatic/morel/AlgebraTest.java
@@ -253,6 +253,13 @@ public class AlgebraTest {
       "from i in [10, 15, 20] union (from d in scott.depts yield d.deptno)",
       "from i in [10, 15, 20] except (from d in scott.depts yield d.deptno)",
       "from i in [10, 15, 20] intersect (from d in scott.depts yield d.deptno)",
+      "List.`except` [[1, 2, 3], [2, 5, 4]]",
+      "List.`intersect` [[1, 2, 3], [2, 5, 4]]",
+      "List.`except` [[1, 2, 3], [2, 5, 4], [2, 1, 6]]",
+      "List.`intersect` [[1, 2, 3], [2, 5, 4], [2, 1, 6]]",
+      "List.`except` [[1, 1, 2, 3], [1]]",
+      "List.`intersect` [[1, 1, 2, 3], [1, 1, 5]]",
+      "List.concat [[1, 2], [3], [4, 5]]",
 
       // the following 4 are equivalent
       "from e in scott.emps where e.deptno = 30 yield e.empno",


### PR DESCRIPTION
Fixes #408.

On the Calcite/HYBRID path, applying the collection built-ins directly (rather than as `from` steps) crashed or gave wrong answers. The native interpreter is correct throughout.

### Cause

The operator-application path in `CalciteCompiler.compileApply` casts `apply.arg` to `Core.Tuple`. That was right when these were the infix pair operators `op union`/`op except`/`op intersect` (the code dates from #40), but since #253 the built-ins take a single argument, a list of collections, which Core represents as a call to `Z_LIST`. So every direct call threw `ClassCastException`:

```
List.`except` [[1, 2, 3], [2, 5, 4]];
(* Core$Apply cannot be cast to Core$Tuple *)
```

Underneath that, the `foldSetOp` calls merged with #402 pass the wrong constants: `Op.MINUS` for `LIST_EXCEPT` (hits the `AssertionError` default inside `foldSetOp`) and `Op.EXCEPT` for `LIST_INTERSECT` (calls `relBuilder.minus`, so intersect computes except). With the cast fixed and the constants left alone, `` List.`intersect` [[1, 2, 3], [2, 5, 4]] `` returns `[1, 3]` rather than `[2]`.

### Fix

Unwrap the `Z_LIST` argument instead of casting to a tuple, falling through to the generic path when the argument is not a literal list, and pass `Op.EXCEPT`/`Op.INTERSECT`.

Add direct-call cases to `AlgebraTest.testQueryList`: two-operand and three-operand `except`/`intersect` (the latter guard the #402 binarization on this path too), multiset cases with duplicates (guarding the EXCEPT ALL/INTERSECT ALL semantics against the native interpreter), and a three-operand `List.concat`.

`./mvnw install` is green.
