### PR TITLE
[MOREL-410] Fix conversion of collections of collections on the Calcite path

### DIFF
--- a/src/main/java/net/hydromatic/morel/foreign/Converters.java
+++ b/src/main/java/net/hydromatic/morel/foreign/Converters.java
@@ -158,6 +158,12 @@ public class Converters {
     if (type instanceof RecordLikeType) {
       return (Converter<E>) ofRow2(fromType, (RecordLikeType) type);
     }
+    if (fromType.isStruct() && fromType.getFieldCount() == 1) {
+      // A single-column row whose Morel type is not a record, e.g. a
+      // collection. The column already holds the Morel value; unwrap it
+      // rather than leaking the Object[] row.
+      return (Converter<E>) (Converter<Object[]>) values -> values[0];
+    }
     if (fromType.isNullable()) {
       return o -> o == null ? BigDecimal.ZERO : o;
     }
@@ -473,6 +479,11 @@ public class Converters {
           }
 
         default:
+          if (morelType.isCollection()) {
+            // The value of a collection-typed column is already a Morel
+            // collection (a List); no conversion is required.
+            return v -> v;
+          }
           throw new AssertionError("unknown type " + morelType);
       }
     }

--- a/src/test/java/net/hydromatic/morel/AlgebraTest.java
+++ b/src/test/java/net/hydromatic/morel/AlgebraTest.java
@@ -253,6 +253,10 @@ public class AlgebraTest {
       "from i in [10, 15, 20] union (from d in scott.depts yield d.deptno)",
       "from i in [10, 15, 20] except (from d in scott.depts yield d.deptno)",
       "from i in [10, 15, 20] intersect (from d in scott.depts yield d.deptno)",
+      "[[1, 2], [3]]",
+      "[bag [1, 2], bag [3]]",
+      "from l in [[1, 2], [3]]",
+      "from l in [[1, 2], [3]] yield List.length l",
 
       // the following 4 are equivalent
       "from e in scott.emps where e.deptno = 30 yield e.empno",


### PR DESCRIPTION
Fixes #410.

On the Calcite/HYBRID path, any collection whose elements are themselves collections came back from Calcite as raw interpreter rows (`Object[]`) rather than Morel values: a `ClassCastException` for anything that touched the elements, or silent value corruption for anything that did not (`[bag [1, 2], bag [3]]` printed `[[Ljava.lang.Object;@5c5c7cc4,...]`). The native interpreter is correct throughout.

### Cause

Two gaps in `Converters`, one per direction:

1. `Converters.forType` handles a `PrimitiveType` element (extract field 0) and a `RecordLikeType` element (row converter), but a collection element type fell through to the identity function, so each element stayed an `Object[]` row. The row is single-column and the column already holds the Morel value (built by `morelScalar`); it just needed unwrapping.

2. `C2m.toMorelObjectFunction`, which `CalciteFunctions.MorelApplyFunction` uses to convert an argument before applying a Morel closure inside a plan, handles `TUPLE_TYPE` and primitives and threw `AssertionError: unknown type int list` for collections (`from l in [[1, 2], [3]] yield List.length l`). The runtime value of a collection-typed operand is already a Morel list, so the identity conversion is the correct one (verified for `List.length`, `List.hd`, and raw element values).

### Fix

In `forType`, unwrap the single column for a non-record element type; in `toMorelObjectFunction`, return the identity function for collection types. Add regression queries to `AlgebraTest.testQueryList`:

```
[[1, 2], [3]]
[bag [1, 2], bag [3]]
from l in [[1, 2], [3]]
from l in [[1, 2], [3]] yield List.length l
```

A further case, `Bag.concat [bag [1, 2], bag [3]]`, is fixed by this change too but its regression test only compiles once #409 lands (without #409 the operator-application path fails earlier, on the tuple cast); it can be added there or after.

`./mvnw install` is green.
