### PR TITLE
[MOREL-415] Fix shell highlighter crash on an unterminated string ending in a backslash

### DIFF
--- a/src/main/java/net/hydromatic/morel/util/MorelHighlighter.java
+++ b/src/main/java/net/hydromatic/morel/util/MorelHighlighter.java
@@ -641,7 +641,9 @@ public class MorelHighlighter {
     while (i < n) {
       char c = s.charAt(i);
       if (c == '\\') {
-        i += 2; // skip escape sequence
+        // Skip escape sequence; clamp so that a trailing backslash in an
+        // unterminated string does not return an index past the buffer.
+        i = Math.min(i + 2, n);
       } else if (c == '"') {
         i++; // skip closing "
         break;

--- a/src/test/java/net/hydromatic/morel/ShellHighlighterTest.java
+++ b/src/test/java/net/hydromatic/morel/ShellHighlighterTest.java
@@ -78,6 +78,23 @@ public class ShellHighlighterTest {
         is(ColorScheme.DARK.style(Category.CONSTANT)));
   }
 
+  /**
+   * An unterminated string ending in a backslash, the state the buffer passes
+   * through when an escape sequence is typed interactively, must not crash the
+   * highlighter.
+   */
+  @Test
+  void testHighlightUnterminatedStringEscape() {
+    final ShellHighlighter h = highlighter("dark");
+    final AttributedStyle string = ColorScheme.DARK.style(Category.STRING);
+    // '"' then '\': the escape skip must not run past the buffer.
+    assertThat(h.highlight(null, "\"\\").styleAt(1), is(string));
+    // Longer prefix of a typed escape, e.g. '"ab\'.
+    assertThat(h.highlight(null, "\"ab\\").styleAt(3), is(string));
+    // A complete escape in an unterminated string.
+    assertThat(h.highlight(null, "\"a\\n").styleAt(3), is(string));
+  }
+
   /** Word, real and scientific literals are styled as numeric. */
   @Test
   void testHighlightNumbers() {


### PR DESCRIPTION
Fixes #415.

The highlighter runs on every keystroke, so the buffer passes through the intermediate state `"\` the moment a string escape is typed; any escaped string hits it during ordinary typing, and the exception escapes into JLine's redisplay path.

### Cause

`MorelHighlighter.scanString` skips an escape with `i += 2` without checking `i + 1 < n`, so an unterminated string ending in a backslash returns an end index one past the buffer. `ShellHighlighter`'s span sink then calls `substring(start, end)` with `end` beyond the length:

```
java.lang.StringIndexOutOfBoundsException: Range [0, 3) out of bounds for length 2
```

### Fix

Clamp the skip to the buffer length. Add regression tests to `ShellHighlighterTest` covering the intermediate states of typing an escaped string (`"\`, `"ab\`, `"a\n`), which also pin that the partial string is still styled as a string.

`./mvnw install` is green.
