### PR TITLE
[MOREL-416] Fix row binder when the binder name equals the record's only field name

### DIFF
--- a/src/main/java/net/hydromatic/morel/ast/FromBuilder.java
+++ b/src/main/java/net/hydromatic/morel/ast/FromBuilder.java
@@ -43,6 +43,7 @@ import net.hydromatic.morel.compile.RefChecker;
 import net.hydromatic.morel.type.Binding;
 import net.hydromatic.morel.type.ListType;
 import net.hydromatic.morel.type.PrimitiveType;
+import net.hydromatic.morel.type.RecordLikeType;
 import net.hydromatic.morel.type.TypeSystem;
 import net.hydromatic.morel.util.Pair;
 import net.hydromatic.morel.util.PairList;
@@ -149,7 +150,8 @@ public class FromBuilder {
         step,
         step.env.ordered);
     steps.add(step);
-    if (!bindings.equals(step.env.bindings)) {
+    if (!bindings.equals(step.env.bindings)
+        || step.env.atom && !bindingsMatch(bindings, step.env.bindings)) {
       bindings.clear();
       bindings.addAll(step.env.bindings);
     }
@@ -555,7 +557,15 @@ public class FromBuilder {
     if (tuple.args.size() != env.bindings.size()) {
       return TupleType.OTHER;
     }
-    boolean identity = env2 == null || env.bindings.equals(env2.bindings);
+    // The output bindings (env2) must match the tuple's fields by name and
+    // type. A row binder whose name equals the record's sole field name
+    // ('yield g = {g = ...}') has a binding named like the field but typed as
+    // the whole record; Binding equality ignores type, so without the type
+    // check the binder would look like the identity and be dropped.
+    boolean identity =
+        env2 == null
+            || env.bindings.equals(env2.bindings)
+                && bindingsMatchFields(env2.bindings, tuple.type());
     for (Pair<Core.Exp, String> argName :
         Pair.zip(tuple.args, tuple.type().argNames())) {
       Core.Exp arg = argName.left;
@@ -568,6 +578,42 @@ public class FromBuilder {
       }
     }
     return identity ? TupleType.IDENTITY : TupleType.RENAME;
+  }
+
+  /**
+   * Returns whether two binding lists are equal, including types ({@link
+   * Binding} equality ignores type). A binder yield {@code g = {g = ...}} can
+   * produce a binding with the same name and ordinal as its input binding but a
+   * different type; {@link #addStep} must let it replace the input binding.
+   */
+  private static boolean bindingsMatch(
+      List<Binding> bindings, List<Binding> bindings2) {
+    if (!bindings.equals(bindings2)) {
+      return false;
+    }
+    for (Pair<Binding, Binding> pair : Pair.zip(bindings, bindings2)) {
+      if (!pair.left.id.type.equals(pair.right.id.type)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Returns whether each binding has the same name and type as a field of the
+   * record type. False for a row binder over a record with one field of the
+   * same name, whose binding's type is the whole record, not the field.
+   */
+  private static boolean bindingsMatchFields(
+      List<Binding> bindings, RecordLikeType recordType) {
+    final List<String> fieldNames = recordType.argNames();
+    for (Binding binding : bindings) {
+      final int i = fieldNames.indexOf(binding.id.name);
+      if (i < 0 || !binding.id.type.equals(recordType.argType(i))) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private Core.Exp build(boolean simplify) {

--- a/src/main/java/net/hydromatic/morel/compile/Compiler.java
+++ b/src/main/java/net/hydromatic/morel/compile/Compiler.java
@@ -758,20 +758,26 @@ public class Compiler {
   }
 
   /**
-   * Returns whether a yielded record's field names exactly match the step's
-   * binding names. True for an ordinary record yield (fields scattered into
-   * like-named bindings) and for the from-flattening rename {@code {e2 = ...}};
-   * false for a row binder {@code yield r = {c = ...}}, whose whole record is
-   * bound to the single name {@code r}.
+   * Returns whether a yielded record's fields exactly match the step's
+   * bindings, by name and type. True for an ordinary record yield (fields
+   * scattered into like-named bindings) and for the from-flattening rename
+   * {@code {e2 = ...}}; false for a row binder {@code yield r = {c = ...}},
+   * whose whole record is bound to the single name {@code r}.
+   *
+   * <p>Types must be compared as well as names: a binder whose name equals its
+   * record's sole field name ({@code yield r = {r = ...}}) has a binding whose
+   * name matches, but its type is the whole record, not the field.
    */
   private static boolean fieldsMatchBindings(
       Core.Tuple tuple, List<Binding> bindings) {
-    final List<String> fieldNames = tuple.type().argNames();
+    final RecordLikeType recordType = tuple.type();
+    final List<String> fieldNames = recordType.argNames();
     if (fieldNames.size() != bindings.size()) {
       return false;
     }
     for (Binding binding : bindings) {
-      if (!fieldNames.contains(binding.id.name)) {
+      final int i = fieldNames.indexOf(binding.id.name);
+      if (i < 0 || !binding.id.type.equals(recordType.argType(i))) {
         return false;
       }
     }

--- a/src/test/resources/script/relational.smli
+++ b/src/test/resources/script/relational.smli
@@ -1043,6 +1043,17 @@ from i in [1,2] yield r = i + 1 join u in [3,4];
 from i in [1,2,3] yield (i = 2);
 > val it = [false,true,false] : bool list
 
+(* A binder whose name equals the record's only field name is still a
+ * binder, not a scattered record yield. *)
+from i in [1,2,3] yield r = {r = i} where r.r > 1;
+> val it = [{r=2},{r=3}] : {r:int} list
+
+from i in [1,2,3] group g = {g = i} where g.g > 1;
+> val it = [{g=2},{g=3}] : {g:int} list
+
+from i in [1,2,3] group g = {g = i} yield g.g;
+> val it = [1,2,3] : int list
+
 (*) singleton record 'yield' followed by singleton 'group'
 from e in emps
   yield {d = e.deptno}


### PR DESCRIPTION
Fixes #416.

```sml
from i in [1,2,3] yield r = {r = i} where r.r > 1;
(*) was: ClassCastException; now: [{r=2},{r=3}] : {r:int} list

from i in [1,2,3] group g = {g = i} where g.g > 1;
(*) was: 'Conversion to core did not preserve type'; now: [{g=2},{g=3}]

from i in [1,2,3] group g = {g = i} yield g.g;
(*) was: ClassCastException; now: [1,2,3] : int list
```

### Cause

Three sites conflated a binder row with an ordinary record yield, all by comparing names (or `Binding`/`IdPat` equality, which ignores type) when the distinguishing feature is the type:

1. `Compiler.fieldsMatchBindings` chooses between scattering record fields into like-named bindings and binding the whole row to one name. A binder over a single-field record whose field shares the binder's name matches spuriously, so the field value is scattered into a name that the type resolver typed as the whole record; downstream field access casts the atom to a record and throws. (An `env.atom` guard is not enough: the from-flattening rename in `FromBuilder.scan` produces single-field renames with the same atom-marked shape that must still scatter.)

2. `FromBuilder.tupleType` classifies the binder yield `g = {g = g}` after `group g = {g = i}` as the identity, so the step is removed as trivial when a further step follows; the type-preservation check then fails.

3. `FromBuilder.addStep` skips refreshing its accumulated bindings when the new step's bindings are equal per `Binding.equals`, so even with the yield kept, later steps were typed against the input binding `g : int` rather than the binder `g : {g:int}`.

### Fix

Compare types as well as names: `fieldsMatchBindings` requires each binding's type to equal its field's type; `tupleType` requires the output bindings to match the tuple's fields by name and type before treating the yield as the identity; `addStep` lets an atom step's own binding replace a same-named input binding of a different type. Existing behavior is unchanged elsewhere: renames and trivial yields have bindings typed as their fields, so the new checks only reject the binder collision.

Add the three queries above to `relational.smli` beside the other binder tests.

`./mvnw install` is green.
